### PR TITLE
Allow selecting where to log to via "logger" preference and add stdout as a recognized output option.

### DIFF
--- a/content/shelveUtils.js
+++ b/content/shelveUtils.js
@@ -458,9 +458,16 @@ var shelveUtils = {
 
     log: function(text, log_level) {
         if (shelveUtils.shouldLog(log_level)) {
-            var aConsoleService = Components.classes['@mozilla.org/consoleservice;1'].
-            getService(Components.interfaces.nsIConsoleService);
-            aConsoleService.logStringMessage('Shelve: ' + text);
+            var logval = shelveStore.getString(null, 'logger', 'none');
+            if (logval == 'none') {
+                // do nothing
+            } else if (logval == 'console') {
+                var aConsoleService = Components.classes['@mozilla.org/consoleservice;1'].
+                getService(Components.interfaces.nsIConsoleService);
+                aConsoleService.logStringMessage('Shelve: ' + text);
+            } else if (logval == 'stdout') {
+                dump('Shelve: ' + text + "\n");
+            }
         }
     },
 


### PR DESCRIPTION
The current log and debug output goes to the error console, which when logging a lot of data slows down firefox.  Also there is a maximum number of message, after which the older ones are deleted.

This patch allows one to log to stdout and thus more easily capture large amounts of data.  Its fairly easy to change where logs go to by setting the preference "extensions.shelve.logger" to either "console" or "stdout".  Log messages will be dropped if set to anything else.

Also, I noticed a lot of commented out log/debug messages in the code.  With this patch it makes it more acceptable to leave those uncommented, since by default the messages will be ignored.
