### PR TITLE
Add support for sending the browser to MAFF when appropriate, allowing more featureful MAFF saving.

### DIFF
--- a/content/shelve.js
+++ b/content/shelve.js
@@ -747,7 +747,8 @@ var shelve = {
         // shelveUtils.debug('autoSelectShelve dclevent.type=', dclevent.type);
         // shelveUtils.debug('autoSelectShelve dclevent.originalTarget=', dclevent.originalTarget);
         // shelveUtils.debug('autoSelectShelve dclevent.originalTarget.url=', dclevent.originalTarget.url);
-        var doc_params = {};
+        // Note: gBrowser should be available anytime after the 'load' event
+        var doc_params = {browser: gBrowser};
         if (dclevent.type == 'DOMContentLoaded') {
             doc_params.doc = dclevent.originalTarget;
             // shelveUtils.debug('shelve.autoShelve DOMContentLoaded doc=', doc_params.doc);
@@ -833,6 +834,8 @@ var shelve = {
                                 // shelveUtils.debug('autoPageParams: ', shelve.autoPageParams);
                                 var app = shelveUtils.clone(shelve.autoPageParams);
                                 // shelveUtils.debug('app0: ', app);
+                                // Note: gBrowser should be available anytime after the 'load' event
+                                app.browser = gBrowser;
                                 app.filename = filename;
                                 app.doc = doc;
                                 app.title = doc.title;
@@ -883,6 +886,9 @@ var shelve = {
                 content_type: doc_params.content_type,
                 auto: false
             };
+            if (doc_params.browser) {
+                sp_params.browser = doc_params.browser;
+            }
             if (doc_params.doc) {
                 sp_params.doc = doc_params.doc;
             }

--- a/content/shelveUtils.js
+++ b/content/shelveUtils.js
@@ -798,7 +798,13 @@ var shelveUtils = {
         if (shelveUtils.isMafEnabled(true)) {
             return function(doc, file, dataPath, outputContentType, encodingFlags, wrapColumn) {
                 var fileUri = shelveUtils.newFileURI(file);
-                var persistObject = new shelveUtils.mafObjects.MafArchivePersist(null, format);
+                var browsers = sp_params.browser;
+                if (!browsers)
+                    browsers = null;
+                else if (!browsers.map) {
+                    browsers = [browsers];
+                }
+                var persistObject = new shelveUtils.mafObjects.MafArchivePersist(browsers, format);
                 if (enable_dlm) {
                     var uri = shelveUtils.newURI(sp_params.url);
                     shelve.registerDownload(persistObject, uri, fileUri, sp_params, null);


### PR DESCRIPTION
By giving the browser to the MAFF creation code, extra metadata can be saved in the MAFF file, such as back/forward history and viewer position.  We only want to give the browser in the case where we want to save the whole page.  For partial saving, such as clippings, we must not pass in the browser.

Currently this is only implemented for the autoshelving feature.  It should probably be done for all whole page saving.
