### PR TITLE
Add option to only save non-frame documents when in autoshelve mode, especially useful for MAFF output.

### DIFF
--- a/content/shelve.js
+++ b/content/shelve.js
@@ -754,9 +754,17 @@ var shelve = {
         } else if (dclevent.type == 'TabSelect') {
             doc_params.doc = dclevent.originalTarget.linkedBrowser.contentDocument;
             // shelveUtils.debug('shelve.autoShelve TabSelect doc=', doc_params.doc);
+        } else if (dclevent.type == 'load') {
+            doc_params.doc = dclevent.target;
         } else {
             doc_params.doc = shelveUtils.getDocument({});
             // shelveUtils.debug('shelve.autoShelve getDocument() doc=', doc_params.doc);
+        }
+        // We want to skip frames because they're mostly garbage
+        if (shelve.getBoolPref(shelve.getPrefs('auto.'), 'no_frames', false) &&
+            !shelveUtils.isTopLevelDoc(doc_params.doc, gBrowser)) {
+            shelveUtils.debug('shelve.autoShelve doc not top level document: ', doc_params.doc.location && doc_params.doc.location.href);
+            return;
         }
         // shelveUtils.debug('autoSelectShelve doc=', doc_params);
         var url = shelveUtils.getDocumentURL(doc_params);
@@ -800,6 +808,12 @@ var shelve = {
             } else {
                 doc = shelveUtils.getDocument({});
                 // shelveUtils.debug('shelve.autoShelve getDocument() doc=', doc);
+            }
+            // We want to skip frames because they're mostly garbage
+            if (shelve.getBoolPref(shelve.getPrefs('auto.'), 'no_frames', false) &&
+                !shelveUtils.isTopLevelDoc(doc, gBrowser)) {
+                shelveUtils.debug('shelve.autoShelve doc not top level document: ', doc.location && doc.location.href);
+                return;
             }
             var docurl = doc.URL;
             if (!docurl) {

--- a/content/shelveUtils.js
+++ b/content/shelveUtils.js
@@ -157,6 +157,31 @@ var shelveUtils = {
         }
     },
 
+    // Determine if document is a document and not a frame
+    isTopLevelDoc: function(doc, browser) {
+        if (doc.nodeName != '#document') {
+            shelveUtils.debug('shelveUtils.isTopLevelDoc doc not document or is frame: ', doc.location && doc.location.href);
+            return false;
+        // If there is a defaultView (window) ...
+        } else if (doc.defaultView) {
+            // ... and its location url is not the same as the current browser, skip
+            // probably this is some kind of frame
+            if (browser && doc.defaultView.location &&
+                (doc.defaultView.location.href != browser.currentURI.spec)) {
+                shelveUtils.debug('shelveUtils.isTopLevelDoc doc\'s url not same as browser\'s: ('+browser.currentURI.spec+'): ', doc.defaultView.location.href);
+                return false;
+            }
+            // ... and it has a parent (window) that is not itself, skip
+            // probably this is some kind of frame
+            else if (doc.defaultView != doc.defaultView.parent) {
+                shelveUtils.debug('shelveUtils.isTopLevelDoc doc not parent document: ', doc.location && doc.location.href);
+                return false;
+            }
+        }
+        
+        return true;
+    },
+
     emptyListbox: function(listbox) {
         listbox.clearSelection();
         while (listbox.getRowCount() > 0) {


### PR DESCRIPTION
When using autoshelve all documents that are loaded (includes frames and iframes) are potentially saved.  The issue is that when using MAFF to save the pages, it will get all those resources and stuff them into the MAFF archive.  Without these changes, you potentially save a lot of unwanted iframes, css and javascript files, etc as MAFFs, when you already have those as resources for the original non-frame top level document.

This feature can be turned on by setting the "extensions.shelve.auto.no_frames" pref.  This should probably be defaulted to on in the case of MAFF.
