### PR TITLE
More/Archival template vars

### DIFF
--- a/content/help.xhtml
+++ b/content/help.xhtml
@@ -82,9 +82,39 @@
                         <td>&shelve.td.query;</td>
                     </tr>
                     <tr>
+                        <th>&nbsp;</th>
+                        <th>%{queryq}</th>
+                        <td>&shelve.td.queryq;</td>
+                    </tr>
+                    <tr>
+                        <th>&nbsp;</th>
+                        <th>%{queryhash}</th>
+                        <td>&shelve.td.queryhash;</td>
+                    </tr>
+                    <tr>
+                        <th>&nbsp;</th>
+                        <th>%{queryhashq}</th>
+                        <td>&shelve.td.queryhashq;</td>
+                    </tr>
+                    <tr>
+                        <th>%d</th>
+                        <th>%{dirname}</th>
+                        <td>&shelve.td.dirname;</td>
+                    </tr>
+                    <tr>
+                        <th>&nbsp;</th>
+                        <th>%{dirnameshorten}</th>
+                        <td>&shelve.td.dirnameshorten;</td>
+                    </tr>
+                    <tr>
                         <th>%p</th>
                         <th>%{fullpath}</th>
                         <td>&shelve.td.path;</td>
+                    </tr>
+                    <tr>
+                        <th>&nbsp;</th>
+                        <th>%{fullpathi}</th>
+                        <td>&shelve.td.pathi;</td>
                     </tr>
                     <tr>
                         <th>%P</th>
@@ -92,14 +122,29 @@
                         <td>&shelve.td.path.no.ext;</td>
                     </tr>
                     <tr>
+                        <th>&nbsp;</th>
+                        <th>%{pathi}</th>
+                        <td>&shelve.td.pathi.no.ext;</td>
+                    </tr>
+                    <tr>
                         <th>%f</th>
                         <th>%{filename}</th>
                         <td>&shelve.td.filename;</td>
                     </tr>
                     <tr>
+                        <th>&nbsp;</th>
+                        <th>%{filenamei}</th>
+                        <td>&shelve.td.filenamei;</td>
+                    </tr>
+                    <tr>
                         <th>%F</th>
                         <th>%{basename}</th>
                         <td>&shelve.td.filename.no.ext;</td>
+                    </tr>
+                    <tr>
+                        <th>&nbsp;</th>
+                        <th>%{basenamei}</th>
+                        <td>&shelve.td.filenamei.no.ext;</td>
                     </tr>
                     <tr>
                         <th>%e</th>
@@ -155,6 +200,11 @@
                         <th>%l</th>
                         <th>%{msecs}</th>
                         <td>&shelve.td.milliseconds;</td>
+                    </tr>
+                    <tr>
+                        <th>&nbsp;</th>
+                        <th>%{archivefilename}</th>
+                        <td>&shelve.td.archivefilename;</td>
                     </tr>
                     <tr>
                         <th>&nbsp;</th>

--- a/content/shelve.js
+++ b/content/shelve.js
@@ -1592,6 +1592,24 @@ var shelve = {
             val = shelve.getDocumentUrlQuery(et_params);
             break;
 
+            case 'queryq':
+            rawmode = true;
+            val = shelve.getDocumentUrlQuery(et_params);
+            val = val ? '?' + val : val;
+            break;
+
+            case 'queryhash':
+            val = shelve.getDocumentUrlQuery(et_params);
+            val = (val) ? shelveUtils.hashstring(val, true).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '') : val;
+            break;
+
+            case 'queryhashq':
+            rawmode = true;
+            val = shelve.getDocumentUrlQuery(et_params);
+            val = (val) ? shelveUtils.hashstring(val, true).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '') : val;
+            val = val ? '?' + val : val;
+            break;
+
             case 'secs':
             val = shelve.lpadString(new Date().getSeconds(), '00');
             break;

--- a/content/shelve.js
+++ b/content/shelve.js
@@ -1682,6 +1682,25 @@ var shelve = {
             rawmode = true;
             break;
 
+            case 'archivefilename':
+            var orig_tmpl = et_params.template;
+            
+            et_params.template = "%{queryhashq}:%e:%{filenamei}";
+            var vars = shelve.expandTemplate(et_params).split(':');
+            var qhash = vars[0], ext = vars[1], fname = vars.slice(2).join(':');
+            
+            val = qhash + ext;
+            if ((fname + val).length > shelveUtils.MAXNAMELEN) {
+                // chop filename to make it fit in MAXNAMELEN with having the qhash
+                // and extension intact.
+                var h = '_' + shelveUtils.hashstring(fname, true).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+                fname = fname.substring(0, shelveUtils.MAXNAMELEN - h.length - val.length) + h;
+            }
+            val = fname + val;
+            et_params.template = orig_tmpl;
+            rawmode = true;
+            break;
+
 
             // log mode
             case 'note':

--- a/content/shelve.js
+++ b/content/shelve.js
@@ -1594,6 +1594,23 @@ var shelve = {
             val = shelve.getDocumentFilename(et_params, 5, true);
             break;
 
+            // Shorten directory components that are too long, while keeping them unique
+            case 'dirnameshorten':
+            rawmode = true;
+            val = shelve.getDocumentFilename(et_params, 5, true);
+            var dirsep = shelveUtils.filenameSeparator();
+            var dircomps = val.split(dirsep);
+            var dirdepth = dircomps.length;
+            for (var i=0; i < dirdepth; i++) {
+                var d = dircomps[i];
+                if (d.length > shelveUtils.MAXNAMELEN) {
+                    var h = '_' + shelveUtils.hashstring(d, true).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+                    dircomps[i] = d.substring(0, shelveUtils.MAXNAMELEN - h.length) + h;
+                }
+            }
+            val = dircomps.join(dirsep);
+            break;
+
             case 'fullpath':
             rawmode = true;
             val = shelve.getDocumentFilename(et_params, 3, is_not_last);

--- a/content/shelve.js
+++ b/content/shelve.js
@@ -1449,6 +1449,7 @@ var shelve = {
     expandVarNames: {
         'c': 'clip',
         'C': 'Clip',
+        'd': 'dirname',
         'D': 'date',
         'e': 'ext',
         'E': 'ext',
@@ -1586,6 +1587,11 @@ var shelve = {
 
             case 'month':
             val = shelve.lpadString(new Date().getMonth() + 1, '00');
+            break;
+
+            case 'dirname':
+            rawmode = true;
+            val = shelve.getDocumentFilename(et_params, 5, true);
             break;
 
             case 'fullpath':
@@ -1989,6 +1995,9 @@ var shelve = {
             case 4: // path
             file = shelve.getDocumentFilename(et_params, 3, is_not_last);
             file = file.replace(/\.\w+$/, '');
+            break;
+            case 5: // dirname
+            file = path.substring(0, path.length - tail.length - 1);
             break;
         }
         file = String(file);

--- a/content/shelve.js
+++ b/content/shelve.js
@@ -1536,8 +1536,18 @@ var shelve = {
             val = shelve.getDocumentFilename(et_params, 2, is_not_last);
             break;
 
+            case 'filenamei':
+            val = shelve.getDocumentFilename(et_params, 2, false);
+            rawmode = true;
+            break;
+
             case 'basename':
             val = shelve.getDocumentFilename(et_params, 1, is_not_last);
+            break;
+
+            case 'basenamei':
+            val = shelve.getDocumentFilename(et_params, 1, false);
+            rawmode = true;
             break;
 
             case 'host':
@@ -1583,9 +1593,19 @@ var shelve = {
             val = shelve.getDocumentFilename(et_params, 3, is_not_last);
             break;
 
+            case 'fullpathi':
+            rawmode = true;
+            val = shelve.getDocumentFilename(et_params, 3, false);
+            break;
+
             case 'path':
             rawmode = true;
             val = shelve.getDocumentFilename(et_params, 4, is_not_last);
+            break;
+
+            case 'pathi':
+            rawmode = true;
+            val = shelve.getDocumentFilename(et_params, 4, false);
             break;
 
             case 'query':

--- a/content/shelveUtils.js
+++ b/content/shelveUtils.js
@@ -784,8 +784,8 @@ var shelveUtils = {
     },
 
     validPlaceholders: function(klass) {
-        var chars = 'cCDeEfFhHBhiIklmMpPqstxyY%/';
-        var names = 'clip|clip!|clipboard|date|input|subdir|host|hostbasename|query|queryhash|queryq|queryhashq|fullpath|path|filename|basename|fullpathi|pathi|filenamei|basenamei|ext|title|keywords|fullyear|year|month|day|hours|minutes|secs|msecs|shelvedir|separator';
+        var chars = 'cCdDeEfFhHBhiIklmMpPqstxyY%/';
+        var names = 'clip|clip!|clipboard|date|input|subdir|host|hostbasename|query|queryhash|queryq|queryhashq|dirname|fullpath|path|filename|basename|fullpathi|pathi|filenamei|basenamei|ext|title|keywords|fullyear|year|month|day|hours|minutes|secs|msecs|shelvedir|separator';
         switch (klass) {
             case 'log':
             case 'footer':

--- a/content/shelveUtils.js
+++ b/content/shelveUtils.js
@@ -694,6 +694,33 @@ var shelveUtils = {
         return shelveUtils.json.decode(json);
     },
 
+    hashstring: function(str, b64encode, method) {
+        var converter =
+          Components.classes["@mozilla.org/intl/scriptableunicodeconverter"].
+            createInstance(Components.interfaces.nsIScriptableUnicodeConverter);
+
+        // we use UTF-8 here, you can choose other encodings.
+        converter.charset = "UTF-8";
+        // result is an out parameter,
+        // result.value will contain the array length
+        var result = {};
+        // data is an array of bytes
+        var data = converter.convertToByteArray(val, result);
+        var ch = Components.classes["@mozilla.org/security/hash;1"]
+                           .createInstance(Components.interfaces.nsICryptoHash);
+
+        if (!method)
+            method = ch.MD5;
+        else if (ch[method])
+            method = ch[method];
+        else
+            throw new Error("Undefined crypto hash method: "+method);
+
+        ch.init(method);
+        ch.update(data, data.length);
+        return ch.finish(b64encode);
+    },
+
     escapeChar: function(text, chars) {
         return text.replace(new RegExp('([' + chars + '])', 'g'), '\\$1');
     },
@@ -758,7 +785,7 @@ var shelveUtils = {
 
     validPlaceholders: function(klass) {
         var chars = 'cCDeEfFhHBhiIklmMpPqstxyY%/';
-        var names = 'clip|clip!|clipboard|date|input|subdir|host|hostbasename|query|fullpath|path|filename|basename|ext|title|keywords|fullyear|year|month|day|hours|minutes|secs|msecs|shelvedir|separator';
+        var names = 'clip|clip!|clipboard|date|input|subdir|host|hostbasename|query|queryhash|queryq|queryhashq|fullpath|path|filename|basename|ext|title|keywords|fullyear|year|month|day|hours|minutes|secs|msecs|shelvedir|separator';
         switch (klass) {
             case 'log':
             case 'footer':

--- a/content/shelveUtils.js
+++ b/content/shelveUtils.js
@@ -785,7 +785,7 @@ var shelveUtils = {
 
     validPlaceholders: function(klass) {
         var chars = 'cCDeEfFhHBhiIklmMpPqstxyY%/';
-        var names = 'clip|clip!|clipboard|date|input|subdir|host|hostbasename|query|queryhash|queryq|queryhashq|fullpath|path|filename|basename|ext|title|keywords|fullyear|year|month|day|hours|minutes|secs|msecs|shelvedir|separator';
+        var names = 'clip|clip!|clipboard|date|input|subdir|host|hostbasename|query|queryhash|queryq|queryhashq|fullpath|path|filename|basename|fullpathi|pathi|filenamei|basenamei|ext|title|keywords|fullyear|year|month|day|hours|minutes|secs|msecs|shelvedir|separator';
         switch (klass) {
             case 'log':
             case 'footer':

--- a/content/shelveUtils.js
+++ b/content/shelveUtils.js
@@ -787,7 +787,7 @@ var shelveUtils = {
 
     validPlaceholders: function(klass) {
         var chars = 'cCdDeEfFhHBhiIklmMpPqstxyY%/';
-        var names = 'clip|clip!|clipboard|date|input|subdir|host|hostbasename|query|queryhash|queryq|queryhashq|dirname|dirnameshorten|fullpath|path|filename|basename|fullpathi|pathi|filenamei|basenamei|ext|title|keywords|fullyear|year|month|day|hours|minutes|secs|msecs|shelvedir|separator';
+        var names = 'clip|clip!|clipboard|date|input|subdir|host|hostbasename|query|queryhash|queryq|queryhashq|dirname|dirnameshorten|fullpath|path|filename|basename|fullpathi|pathi|filenamei|basenamei|archivefilename|ext|title|keywords|fullyear|year|month|day|hours|minutes|secs|msecs|shelvedir|separator';
         switch (klass) {
             case 'log':
             case 'footer':

--- a/content/shelveUtils.js
+++ b/content/shelveUtils.js
@@ -42,6 +42,8 @@
 
 
 var shelveUtils = {
+    // Constants
+    MAXNAMELEN: 255,
 
     // // Based on http://stackoverflow.com/questions/3774008/cloning-a-javascript-object
     // clone: (function(){ 
@@ -785,7 +787,7 @@ var shelveUtils = {
 
     validPlaceholders: function(klass) {
         var chars = 'cCdDeEfFhHBhiIklmMpPqstxyY%/';
-        var names = 'clip|clip!|clipboard|date|input|subdir|host|hostbasename|query|queryhash|queryq|queryhashq|dirname|fullpath|path|filename|basename|fullpathi|pathi|filenamei|basenamei|ext|title|keywords|fullyear|year|month|day|hours|minutes|secs|msecs|shelvedir|separator';
+        var names = 'clip|clip!|clipboard|date|input|subdir|host|hostbasename|query|queryhash|queryq|queryhashq|dirname|dirnameshorten|fullpath|path|filename|basename|fullpathi|pathi|filenamei|basenamei|ext|title|keywords|fullyear|year|month|day|hours|minutes|secs|msecs|shelvedir|separator';
         switch (klass) {
             case 'log':
             case 'footer':

--- a/locale/en-US/shelve_help.dtd
+++ b/locale/en-US/shelve_help.dtd
@@ -19,10 +19,19 @@
 <!ENTITY shelve.td.host "Host">
 <!ENTITY shelve.td.base.hostname "Base Hostname">
 <!ENTITY shelve.td.query "Query (the part in the URL after the questionmark)">
+<!ENTITY shelve.td.queryq "Same as &apos;query&apos; but prepending a &apos;?&apos;">
+<!ENTITY shelve.td.queryhash "A unique hash of &apos;query&apos; where the characters are only a-z, 0-9, _, and -">
+<!ENTITY shelve.td.queryhashq "Same as &apos;queryhash&apos; but prepending a &apos;?&apos;">
+<!ENTITY shelve.td.dirname "Path without the filename">
+<!ENTITY shelve.td.dirnameshorten "Same as dirname except each directory component will be shortened and made unique if it is longer than the maximum allowed length for the filesystem.">
 <!ENTITY shelve.td.path "Path">
+<!ENTITY shelve.td.pathi "Path (append &apos;index&apos; if ends with &apos;/&apos;)">
 <!ENTITY shelve.td.path.no.ext "Path (no ext)">
+<!ENTITY shelve.td.pathi.no.ext "Path (no ext, append &apos;index&apos; if ends with &apos;/&apos;)">
 <!ENTITY shelve.td.filename "Filename">
+<!ENTITY shelve.td.filenamei "Filename (append &apos;index&apos; if ends with &apos;/&apos;)">
 <!ENTITY shelve.td.filename.no.ext "Filename (no ext)">
+<!ENTITY shelve.td.filenamei.no.ext "Filename (no ext, append &apos;index&apos; if ends with &apos;/&apos;)">
 <!ENTITY shelve.td.extension "Extension">
 <!ENTITY shelve.td.title "Title">
 <!ENTITY shelve.td.keywords "Keywords">
@@ -40,6 +49,7 @@
 <!ENTITY shelve.td.output.file "Output file">
 <!ENTITY shelve.td.relative.output.file "Output filename relative to the log file">
 <!ENTITY shelve.td.url "URL">
+<!ENTITY shelve.td.archivefilename "A filename that can be used for archival purposes. It will be unique across GET requests and ensures that the length of the filename does not exceed the filesystem max.">
 <!ENTITY shelve.td.shelf.name "Shelf name">
 <!ENTITY shelve.td.separator "Filename separator">
 <!ENTITY shelve.td.shelvedir "'shelve' sub-directory located in the user profile directory">


### PR DESCRIPTION
This is a fairly large change set, I can break it down if you want but then the separate pull requests will have to be done in order because they will depend on the previous one.  These changes are mostly to support my use in shelve as a web history archiving plugin.

Many new variables were added, some just variations of existing ones.  This lead to the rewrite of shelve.getDocumentFilename, which should be now be simpler and more efficient.  Some of the new variables are queryhash (for getting the md5 hash of the query string), dirnameshorten (for getting the directory path with all path components exceeding the filesystem filename limit shorted and appended with a hash of the unshortened name to preserve uniqueness), archivefilename (filename unique across GET requests which tries to preserve as much of the original filename as possible), and several others.
